### PR TITLE
Improving the response entity

### DIFF
--- a/src/metal/http/mod.rs
+++ b/src/metal/http/mod.rs
@@ -28,6 +28,7 @@ pub fn match_method(method: &str) -> Result<Method, String> {
 }
 
 #[allow(dead_code)]
+#[derive(Debug)]
 pub enum Status {
     Continue, //100
     SwitchingProtocol, //101

--- a/src/metal/message/mod.rs
+++ b/src/metal/message/mod.rs
@@ -1,4 +1,5 @@
 use super::http::Method;
+use super::http::Status;
 
 #[derive(Debug)]
 pub struct Request {
@@ -8,7 +9,20 @@ pub struct Request {
     pub cookies: Cookies
 }
 
-pub struct Response;
+#[derive(Debug)]
+pub struct Response {
+    pub status : Status,
+    pub headers: Headers
+}
+
+impl Default for Response {
+    fn default() -> Response {
+        Response {
+            status : Status::Ok,
+            headers : Headers::default()
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Path {

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -22,7 +22,7 @@ impl Metal {
                 let mut buffer: [u8; 2048] = [0; 2048];
                 stream.read(&mut buffer).unwrap();
                 let request_parsed = parser::incomming_message(&buffer[..]);
-                let response = message::Response;
+                let response = message::Response::default();
                 if request_parsed.is_err() {
                     // make changes to request and trown message error
                 }else{


### PR DESCRIPTION
The response entity, for now, will have the status and the headers, so it will enable us to parse the entity to the response.